### PR TITLE
When resolving dompurify under mermaid@9.3.0, use 2.5.0 instead of 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,10 @@
     "tinacms": "^2.7.5",
     "tw-animate-css": "^1.2.4",
     "usehooks-ts": "^3.1.1"
+  },
+  "pnpm":{
+    "overrides": {
+      "mermaid@9.3.0>dompurify": "2.5.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  mermaid@9.3.0>dompurify: 2.5.0
+
 importers:
 
   .:
@@ -5211,8 +5214,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@2.4.1:
-    resolution: {integrity: sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA==}
+  dompurify@2.5.0:
+    resolution: {integrity: sha512-5RXhAXSCrKTqt9pSbobT9PVRX+oPpENplTZqCiK1l0ya+ZOzwo9kqsGLbYRsAhzIiLCwKEy99XKSSrqnRTLVcw==}
 
   dompurify@3.2.4:
     resolution: {integrity: sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==}
@@ -14774,7 +14777,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@2.4.1: {}
+  dompurify@2.5.0: {}
 
   dompurify@3.2.4:
     optionalDependencies:
@@ -16192,7 +16195,7 @@ snapshots:
       '@braintree/sanitize-url': 6.0.4
       d3: 7.9.0
       dagre-d3-es: 7.0.6
-      dompurify: 2.4.1
+      dompurify: 2.5.0
       khroma: 2.1.0
       lodash-es: 4.17.21
       moment-mini: 2.29.4


### PR DESCRIPTION
Closes #23 